### PR TITLE
Fix doc build docutils-related issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = ["tdqm", "numpy", "joblib"]
 doc = [
     "jupyter",
     "nbsphinx",
-    "nbsphinx_link",
+    "nbsphinx_link@git+https://github.com/maurerle/nbsphinx-link.git@fix_paths",
     "sphinx",
     "sphinx_gallery",
     "pydata-sphinx-theme",


### PR DESCRIPTION
There's a mismatch between `docutils` and `nbphinx_link`.

When using `docutils 0.22.4` together with `nbsphinx-link 1.3.1`, the following error appears

```
File "/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/sphinx/registry.py", line 553, in load_extension
        raise ExtensionError(
    sphinx.errors.ExtensionError: Could not import extension nbsphinx_link (exception: No module named 'docutils.utils.error_reporting')
```

This issue started being addressed in https://github.com/vidartf/nbsphinx-link/pull/26.
Momentarily, we install this version (https://github.com/maurerle/nbsphinx-link/tree/fix_paths).